### PR TITLE
Fix integrity error when currentAsset is undefined 🐛

### DIFF
--- a/source/ReactLoadableSSRAddon.js
+++ b/source/ReactLoadableSSRAddon.js
@@ -210,7 +210,7 @@ export default class ReactLoadableSSRAddon {
 
       for (let i = 0; i < files.length; i += 1) {
         const file = files[i];
-        const currentAsset = originAssets[file];
+        const currentAsset = originAssets[file] || {};
         const ext = getFileExtension(file).replace(/^\.+/, '').toLowerCase();
 
         if (!assets[id]) { assets[id] = {}; }
@@ -226,14 +226,12 @@ export default class ReactLoadableSSRAddon {
             );
           }
 
-          if (currentAsset) {
-            assets[id][ext].push({
-              file,
-              hash,
-              publicPath: url.resolve(this.options.publicPath || '', file),
-              integrity: currentAsset[this.options.integrityPropertyName],
-            });
-          }
+          assets[id][ext].push({
+            file,
+            hash,
+            publicPath: url.resolve(this.options.publicPath || '', file),
+            integrity: currentAsset[this.options.integrityPropertyName],
+          });
         }
       }
     });

--- a/source/ReactLoadableSSRAddon.js
+++ b/source/ReactLoadableSSRAddon.js
@@ -226,12 +226,14 @@ export default class ReactLoadableSSRAddon {
             );
           }
 
-          assets[id][ext].push({
-            file,
-            hash,
-            publicPath: url.resolve(this.options.publicPath || '', file),
-            integrity: currentAsset[this.options.integrityPropertyName],
-          });
+          if (currentAsset) {
+            assets[id][ext].push({
+              file,
+              hash,
+              publicPath: url.resolve(this.options.publicPath || '', file),
+              integrity: currentAsset[this.options.integrityPropertyName],
+            });
+          }
         }
       }
     });


### PR DESCRIPTION
## Description
Fix error: Cannot read property 'integrity' of undefined
## Why
In case of using `react-loadable-ssr-addon` with dynamic imported component; when a component is removed from the project, `react-loadable-ssr-addon` throw error because currentAsset file is missing, we need to check `currentAsset` variable before getting it's integrity
```
my-project/node_modules/react-loadable-ssr-addon/lib/ReactLoadableSSRAddon.js:193
            integrity: currentAsset[_this.options.integrityPropertyName]
                                   ^

TypeError: Cannot read property 'integrity' of undefined
    at my-project/node_modules/react-loadable-ssr-addon/lib/ReactLoadableSSRAddon.js:193:36
    at Map.forEach (<anonymous>)
    at ReactLoadableSSRAddon.processAssets (my-project/node_modules/react-loadable-ssr-addon/lib/ReactLoadableSSRAddon.js:151:23)
    at ReactLoadableSSRAddon.handleEmit (my-project/node_modules/react-loadable-ssr-addon/lib/ReactLoadableSSRAddon.js:140:10)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (my-project/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:7:1)
    at Compiler.emitAssets (my-project/node_modules/webpack/lib/Compiler.js:441:19)
    at onCompiled (my-project/node_modules/webpack/lib/Watching.js:50:19)
    at hooks.afterCompile.callAsync.err (my-project/node_modules/webpack/lib/Compiler.js:630:14)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (my-project/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:6:1)
    at compilation.seal.err (my-project/node_modules/webpack/lib/Compiler.js:627:30)
```
