### PR TITLE
🐛 add missing entrypoints to origins

### DIFF
--- a/source/ReactLoadableSSRAddon.js
+++ b/source/ReactLoadableSSRAddon.js
@@ -143,6 +143,9 @@ class ReactLoadableSSRAddon {
     }
 
     if (origins.size === 0) { return [names[0] || id]; }
+    if (this.entrypoints.has(names[0])) {
+      origins.add(names[0]);
+    }
 
     return Array.from(origins);
   }


### PR DESCRIPTION
## Summary
Add missing entrypoints to the origins list

## Why
Fixes https://github.com/themgoncalves/react-loadable-ssr-addon/issues/8

*Background:*
- webpack 3
- code splitting a large react app

Extract from the webpack.config.js
```js
new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', minChunks: isExternal }),
new webpack.optimize.CommonsChunkPlugin({ children: true, minChunks: 3 }),
new webpack.optimize.CommonsChunkPlugin({ name: 'runtime', minChunks: Infinity }),
```

While investing ways of doing SSR + Code Splitting on a large code base that predates framework like Next.js or React Loadable, I came across React Loadable and your Addon.

After a bit a tinkering I was able to first do a "route level" code splitting with SSR that worked. But the chunks generated shared a lot of code and where pretty big, defeating the purpose of code splitting for us.
I looked for ways to reduce the duplication of dependencies across the chunks and came across this article [webpack bits: Getting the most out of the CommonsChunkPlugin()](https://medium.com/webpack/webpack-bits-getting-the-most-out-of-the-commonschunkplugin-ab389e5f318)
That's when I added this part:
```js
new webpack.optimize.CommonsChunkPlugin({ children: true, minChunks: 3 }),
```
and it produced the expected result: the main bundle (entry point) was bigger and the chuncks much smaller.

The issue I faced then is that, when running `react-loadable-ssr-addon` webpack plugin, the generated manifest was not listing my `main` entrypoint in the `origins` anymore for some reason.

That's when I found the issue linked above and the proposed solution, I tested it out and it worked like a charm.

I did not investigate much further, test are passing but I did not add new ones for this use case.

## Checklist

- [x] Your code builds clean without any `errors` or `warnings`
- [ ] You are using `approved terminology`
- [ ] You have added `unit tests`, if apply.
