### PR TITLE
:bug: Add all chunks from stats object

### DIFF
--- a/source/ReactLoadableSSRAddon.js
+++ b/source/ReactLoadableSSRAddon.js
@@ -192,7 +192,7 @@ class ReactLoadableSSRAddon {
       return 0;
     };
 
-    return compilationChunks.map((chunk) => {
+    return compilationChunks.reduce((chunks, chunk) => {
       const siblings = new Set();
 
       if (chunk.groupsIterable) {
@@ -208,15 +208,19 @@ class ReactLoadableSSRAddon {
         }
       }
 
-      return {
-        id: chunk.id,
-        names: chunk.name ? [chunk.name] : [],
-        files: chunk.files.slice(),
-        hash: chunk.renderedHash,
-        siblings: Array.from(siblings).sort(compareId),
-        modules: chunk.getModules(),
-      };
-    });
+      chunk.ids.forEach((id) => {
+        chunks.push({
+          id,
+          names: chunk.name ? [chunk.name] : [],
+          files: chunk.files.slice(),
+          hash: chunk.renderedHash,
+          siblings: Array.from(siblings).sort(compareId),
+          modules: chunk.getModules(),
+        });
+      });
+
+      return chunks;
+    }, []);
   }
 
   /**


### PR DESCRIPTION
## Summary

In my project, I encountered an error (see below), in the end I found out that not all chunks are added to manifest, I tried to fix it.

## Why

In my code, I ran into a problem when the chunk is used, but was not defined in the assets property, which is why I got the following error (from getBundles).

```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Array.reduce (<anonymous>)TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Array.reduce (<anonymous>)
```

As a rule, `chunk.ids` contains only one element - this is `chunk.id`, but there are cases when there may be several ids, and it seems to me that we should take this fact into account.

@themgoncalves honestly, I don’t know for sure if this solution is right, but it solved my problem. I would be grateful if you could help me improve this change.

## Checklist

- [x] Your code builds clean without any `errors` or `warnings`
- [x] You are using `approved terminology`
- [ ] You have added `unit tests`, if apply.
