### PR TITLE
:bug: safer getBundles

### DIFF
--- a/source/getBundles.js
+++ b/source/getBundles.js
@@ -24,7 +24,7 @@ function getBundles(manifest, chunks) {
   }, []);
 
   return assetsKey.reduce((bundle, asset) => {
-    Object.keys(manifest.assets[asset]).forEach((key) => {
+    Object.keys(manifest.assets[asset] || {}).forEach((key) => {
       const content = manifest.assets[asset][key];
       if (!bundle[key]) { bundle[key] = []; }
       bundle[key] = unique([...bundle[key], ...content]);


### PR DESCRIPTION
## Summary

Docusaurus v2: this plugin throws.

We write a manifest simply with:

```
        new ReactLoadableSSRAddon({
          filename: clientManifestPath,
        }),
```

Then we read it with `getBundles(manifest, modulesToBeLoaded);`

This leads to errors like:

![image](https://user-images.githubusercontent.com/749374/84062940-6d40ce00-a9c0-11ea-89ba-314cdb76eaa8.png)


## Why

Fix error reported by Docusaurus 2 user here: https://github.com/facebook/docusaurus/issues/2898

There is a Github repro, the manifest gets written to `.docusaurus/client-manifest.json` if you want to take a look.

I've uploaded the manifest here: https://gist.github.com/slorber/f1ba0d0fd4b7e22f0464a9782a9f9395

The asset 14 seems to be missing, producing the `Object.keys(undefined)` error


## Checklist

At this point I'd like to know if this fix seems legit to you. For the Docusaurus 2 usecase it seems to work, as I was able to build the site.

Maybe this manifest issue hides a deeper problem. In such case we should rather keep a fail-fast behavior and fix the underlying issue instead?

Or maybe it's safe to ignore a missing asset in the manifest, I have no idea 🤪 

- [ ] Your code builds clean without any `errors` or `warnings`
- [ ] You are using `approved terminology`
- [ ] You have added `unit tests`, if apply.


