### PR TITLE
🐛 Fix chunk.getModules() webpack 5 deprecation warning

### DIFF
--- a/source/ReactLoadableSSRAddon.js
+++ b/source/ReactLoadableSSRAddon.js
@@ -183,9 +183,10 @@ class ReactLoadableSSRAddon {
    * It tries to mimic https://github.com/webpack/webpack/blob/webpack-4/lib/Stats.js#L632
    * implementation without expensive operations
    * @param {array} compilationChunks
+   * @param {array} chunkGraph
    * @returns {array}
    */
-  getMinimalStatsChunks(compilationChunks) {
+  getMinimalStatsChunks(compilationChunks, chunkGraph) {
     const compareId = (a, b) => {
       if (typeof a !== typeof b) {
         return typeof a < typeof b ? -1 : 1;
@@ -218,8 +219,9 @@ class ReactLoadableSSRAddon {
           files: this.ensureArray(chunk.files).slice(),
           hash: chunk.renderedHash,
           siblings: Array.from(siblings).sort(compareId),
-          // TODO: This is the final deprecation warning needing to be solved.
-          modules: chunk.getModules(),
+          // Webpack5 emit deprecation warning for chunk.getModules()
+          // "DEP_WEBPACK_CHUNK_GET_MODULES"
+          modules: WEBPACK_5 ? chunkGraph.getChunkModules(chunk) : chunk.getModules(),
         });
       });
 
@@ -247,7 +249,7 @@ class ReactLoadableSSRAddon {
       || '';
     this.getEntrypoints(this.stats.entrypoints);
 
-    this.getAssets(this.getMinimalStatsChunks(compilation.chunks));
+    this.getAssets(this.getMinimalStatsChunks(compilation.chunks, compilation.chunkGraph));
     this.processAssets(compilation.assets);
     this.writeAssetsFile();
 


### PR DESCRIPTION
## Summary

Follow-up of the work of @RDIL for Docusaurus 2 to support Webpack 5 (https://github.com/facebook/docusaurus/pull/4089)

We have a Webpack 5 deprecation warning: `chunk.getModules()` is deprecated and should be replaced by the `chunkGraph` API.

```
(node:38087) [DEP_WEBPACK_CHUNK_GET_MODULES] DeprecationWarning: Chunk.getModules: Use new ChunkGraph API
    at Function.getChunkGraphForChunk (/Users/sebastienlorber/Desktop/projects/docusaurus/node_modules/webpack/lib/ChunkGraph.js:1542:10)
    at Chunk.getModules (/Users/sebastienlorber/Desktop/projects/docusaurus/node_modules/webpack/lib/Chunk.js:217:21)
    at /Users/sebastienlorber/Desktop/projects/docusaurus/node_modules/react-loadable-ssr-addon-webpack-5/lib/ReactLoadableSSRAddon.js:154:26
    at Array.forEach (<anonymous>)
    at /Users/sebastienlorber/Desktop/projects/docusaurus/node_modules/react-loadable-ssr-addon-webpack-5/lib/ReactLoadableSSRAddon.js:147:17
    at Array.reduce (<anonymous>)
```

To help review, wasn't able to find doc about the new `ChunkGraph` API, but it seems it is equivalent, as `getModules()` use this new API now and just add a deprecation warning

```
	getModules() {
		return ChunkGraph.getChunkGraphForChunk(
			this,
			"Chunk.getModules",
			"DEP_WEBPACK_CHUNK_GET_MODULES"
		).getChunkModules(this);
	}
```

## Why

Support Webpack 5 without warnings

## Checklist

- [X] Your code builds clean without any `errors` or `warnings`
- [X] You are using `approved terminology`
- [ ] You have added `unit tests`, if apply.

## Emojis for categorizing pull requests:

🐛 Bug fix (`:bug:`)  

