### PR TITLE
:bug: mkdirSync recursively

### DIFF
--- a/source/ReactLoadableSSRAddon.js
+++ b/source/ReactLoadableSSRAddon.js
@@ -327,7 +327,7 @@ class ReactLoadableSSRAddon {
     const json = JSON.stringify(this.manifest, null, 2);
     try {
       if (!fs.existsSync(fileDir)) {
-        fs.mkdirSync(fileDir);
+        fs.mkdirSync(fileDir, { recursive: true });
       }
     } catch (err) {
       if (err.code !== 'EEXIST') {


### PR DESCRIPTION
## Summary
Support writing to nested `output.path`.

## Why
Without the recursive flag, any subdirectory that doesn't exist will throw.

## Checklist

- [ ] Your code builds clean without any `errors` or `warnings`
- [ ] You are using `approved terminology`
- [ ] You have added `unit tests`, if apply.
