### PR TITLE
:bug: getBundles shouldn't require webpack

### DIFF
--- a/source/ReactLoadableSSRAddon.js
+++ b/source/ReactLoadableSSRAddon.js
@@ -12,10 +12,6 @@ import { getFileExtension, computeIntegrity, hasEntry } from './utils';
 // Webpack plugin name
 const PLUGIN_NAME = 'ReactLoadableSSRAddon';
 
-const WEBPACK_VERSION = require('webpack/package.json').version;
-
-const WEBPACK_5 = WEBPACK_VERSION.startsWith('5.');
-
 // Default plugin options
 const defaultOptions = {
   filename: 'assets-manifest.json',
@@ -41,6 +37,7 @@ class ReactLoadableSSRAddon {
     this.entrypoints = new Set();
     this.assetsByName = new Map();
     this.manifest = {};
+    this.isWebpack5 = require('webpack/package.json').version.startsWith('5.');
   }
 
   /**
@@ -136,7 +133,7 @@ class ReactLoadableSSRAddon {
   /* eslint-disable class-methods-use-this */
   getChunkOrigin({ id, names, modules }) {
     const origins = new Set();
-    if (!WEBPACK_5) {
+    if (!this.isWebpack5) {
       // webpack 5 doesn't have 'reasons' on chunks any more
       // this is a dirty solution to make it work without throwing
       // an error, but does need tweaking to make everything work properly.
@@ -346,7 +343,7 @@ class ReactLoadableSSRAddon {
    * @returns {*[]}
    */
   ensureArray(source) {
-    if (WEBPACK_5) {
+    if (this.isWebpack5) {
       return Array.from(source);
     }
     return source;


### PR DESCRIPTION
## Summary
The below import is failing in production
```js
import { getBundles } from 'react-loadable-ssr-addon';
```
```sh
17:57:36   Error: Cannot find module 'webpack/package.json'
17:57:36   Require stack:
17:57:36   - /src/node_modules/react-loadable-ssr-addon/lib/ReactLoadableSSRAddon.js
17:57:36   - /src/node_modules/react-loadable-ssr-addon/lib/index.js
```

## Why
This library is exported as CommonJS, which means treeshaking is not supported. When importing `getBundles` from the `index.js` as described in the README, the module `ReactLoadableSSRAddon` is also loaded which was requiring webpack (a devDependency) during server execution in production (where devDependencies are pruned).

A better fix would be to export this library to ESM as well, and define a `"module": "./esm/index.js"` export in the package.json, along with a `"sideEffects": false` to allow proper importing of named exports.

## Workaround
To workaround this issue, I had to change my import to
```js
import getBundles from 'react-loadable-ssr-addon/lib/getBundles';
```

## Checklist

- [ ] Your code builds clean without any `errors` or `warnings`
- [ ] You are using `approved terminology`
- [ ] You have added `unit tests`, if apply.

## Emojis for categorizing pull requests:

⚡️ New feature (`:zap:`)
🐛 Bug fix (`:bug:`)  
🔥 P0 fix (`:fire:`)  
✅ Tests (`:white_check_mark:`)  
🚀 Performance improvements (`:rocket:`)  
🖍 CSS / Styling (`:crayon:`)  
♿ Accessibility (`:wheelchair:`)  
🌐 Internationalization (`:globe_with_meridians:`)  
📖 Documentation (`:book:`)  
🏗 Infrastructure / Tooling / Builds / CI (`:building_construction:`)  
⏪ Reverting a previous change (`:rewind:`)  
♻️ Refactoring (like moving around code w/o any changes) (`:recycle:`)  
🚮 Deleting code (`:put_litter_in_its_place:`)
